### PR TITLE
config parameter

### DIFF
--- a/.github/workflows/crowdin-wf.yml
+++ b/.github/workflows/crowdin-wf.yml
@@ -36,7 +36,6 @@ jobs:
         localization_branch_name: 'l10n_crowdin_translations'
         create_pull_request: true
         # global options
-        config: '/crowdin.yml'
         dryrun_action: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
You may skip `/` in case the config is in the root or skip the parameter at all. If you want to put config file in directory, then use `dir_name/crowdin.yml`